### PR TITLE
取编辑器内容改用id

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -10,7 +10,7 @@
             <p>{!! old($column, $value) !!}</p>
         </div>
 
-        <input type="hidden" name="{{$name}}" value="{{ old($column, $value) }}" />
+        <input id="input-{{$id}}" type="hidden" name="{{$name}}" value="{{ old($column, $value) }}" />
 
         @include('admin::form.help-block')
 

--- a/src/Editor.php
+++ b/src/Editor.php
@@ -19,6 +19,7 @@ class Editor extends Field
     public function render()
     {
         $name = $this->formatName($this->column);
+        $id = $this->formatName($this->id);
 
         $config = (array) WangEditor::config('config');
 
@@ -39,7 +40,7 @@ editor.customConfig.uploadImgParams = {_token: '$token'}
 Object.assign(editor.customConfig, {$config})
 
 editor.customConfig.onchange = function (html) {
-    $('input[name=$name]').val(html);
+    $('#input-$id').val(html);
 }
 editor.create()
 


### PR DESCRIPTION
当字段是一个关联时，取内容时的属性选择器变成: input[name=xx[xx]]，这不是一个合法的选择器，报错。